### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
-#Contributing
+# Contributing
 If you have a change you would like to make, please submit any pull requests to the `develop` branch, or make a feature branch from `develop`.

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@
 
 ```
 [![](https://travis-ci.org/brahalla/Cerberus.svg)](https://travis-ci.org/brahalla/Cerberus) [![](https://coveralls.io/repos/brahalla/Cerberus/badge.svg?branch=master&service=github)](https://coveralls.io/github/brahalla/Cerberus?branch=master) [![](https://badges.gitter.im/brahalla/Cerberus.svg)](https://gitter.im/brahalla/Cerberus?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-##About
+## About
 Cerberus is a demonstration of a completely stateless and RESTful token-based authorization system using JSON Web Tokens (JWT) and Spring Security.
 
-##Why?
+## Why?
 For an API to be truly RESTful, no application state can be stored on the server itself. One particular challenge in implementing this is ensuring that your API is secure. Cerberus is the answer to this problem; access to the endpoints in the API requires a JSON Web Token to be present in the request header. This token is obtained by successfully performing an authentication request with the API, and afterwards this token will grant access to the API based on the authorities granted to the specified user.
 
-##Requirements
+## Requirements
 Cerberus requires Maven and Java 1.7 or greater.
 
-##Usage
+## Usage
 To use start Cerberus, run in the terminal `mvn spring-boot:run`. Cerberus will now be running at `http://localhost:8080/api/`
 
 There are two built-in user accounts to demonstrate the differing levels of access to the endpoints in the API:
@@ -66,5 +66,5 @@ You should get an HTTP 200 and the response `:O`
 
 Tokens are configured to expire after a week. To ensure that a token remains fresh and does not expire, you can refresh an existing token by sending a GET to `/api/auth/refresh` with the token set in the request header. The response will be a new token with an updated expiration date. This refresh mechanism only works for tokens that have not expired yet, unless the token was provided to a mobile device. Tokens for mobile devices can always be refreshed.
 
-##Testing
+## Testing
 To run Cerberus's unit tests, run in the terminal `mvn clean package`.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
